### PR TITLE
Make catbox-redis support unixsocket

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,12 @@ internals.Connection.prototype.start = function (callback) {
         return Hoek.nextTick(callback)();
     }
 
-    var client = Redis.createClient(this.settings.port, this.settings.host);
+    if (this.settings.unixsocket) {
+        var client = Redis.createClient(this.settings.unixsocket);
+    }
+    else {
+        var client = Redis.createClient(this.settings.port, this.settings.host);
+    }
 
     if (this.settings.password) {
         client.auth(this.settings.password);


### PR DESCRIPTION
In development we use a redis server running as a child process of node on a unixsocket, and node_redis connects to it over the socket. This small change would enable us to use hapi/catbox caching in our environment (doesn't work as is since catbox-redis expects the redis server to connect using host and port).

Its probably not that common, but this is a small non-invasive change. I have tested it, but I did not add any tests as I didn't want to require you to setup a redis server this way for your test suite.
