### PR TITLE
Update README, unix domain socket can be specified in port property

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ Redis adapter for catbox
 ### Options
 
 - `host` - the Redis server hostname. Defaults to `'127.0.0.1'`.
-- `port` - the Redis server port. Defaults to `6379`.
+- `port` - the Redis server port or unix domain socket path. Defaults to `6379`.
 - `password` - the Redis authentication password when required.
 


### PR DESCRIPTION
Add mention about how to use a unix domain socket in the README.

To use a unix domain socket, set port property to the path to the
socket rather than a numeric TCP port. The host property will be
ignored by the underlying net.connection constructor.
