### PR TITLE
add instructions for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,18 @@ Redis adapter for catbox
 
 Lead Maintainer: [Eran Hammer](https://github.com/hueniverse)
 
-### Options
+## Options
 
 - `host` - the Redis server hostname. Defaults to `'127.0.0.1'`.
 - `port` - the Redis server port or unix domain socket path. Defaults to `6379`.
 - `password` - the Redis authentication password when required.
 - `partition` - this will store items under keys that start with this value. (Default: '')
+
+## Tests
+
+The test suite expects a redis server to be running on port 6379.
+
+```sh
+redis-server&
+npm test
+```


### PR DESCRIPTION
This is a fix for https://github.com/hapijs/catbox-redis/issues/12. Just a note in the readme about running `redis-server`.