### PR TITLE
Add support for connecting to Unix domain sockets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,12 +32,19 @@ internals.Connection.prototype.start = function (callback) {
         return Hoek.nextTick(callback)();
     }
 
-    var client = Redis.createClient(this.settings.port, this.settings.host);
+    var client;
+
+    if (this.settings.socket) {
+        client = Redis.createClient(this.settings.socket);
+    }
+    else {
+        client = Redis.createClient(this.settings.port, this.settings.host);
+    }
 
     if (this.settings.password) {
         client.auth(this.settings.password);
     }
-    
+
     if (this.settings.database) {
         client.select(this.settings.database);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -397,23 +397,41 @@ describe('Redis', function () {
                 done();
             });
         });
-        
+
         it('sends select command when database is provided', function (done) {
             var options = {
                 host: '127.0.0.1',
                 port: 6379,
                 database: 1
             };
-            
+
             var redis = new Redis(options);
-            
+
             redis.start(function () {});
-            
+
             // redis.client.selected_db gets updated after the callback
             setTimeout(function () {
                 expect(redis.client.selected_db).to.equal(1);
                 done();
             }, 10);
+        });
+
+        it('connects to a unix domain socket when one is provided.', function (done) {
+
+            var options = {
+                socket: "/var/run/redis/redis.sock"
+            };
+
+            var redis = new Redis(options);
+
+            redis.start(function (err) {
+
+                var client = redis.client;
+                expect(client).to.exist();
+                expect(client.connected).to.equal(true);
+                expect(client.address).to.equal(options.socket);
+                done();
+            });
         });
 
         it('stops the client on error post connection', function (done) {


### PR DESCRIPTION
I would like to use a unix domain socket when connecting to redis.  This PR adds that ability.  When investigating `node-redis` I discovered that it triggers its own socket support by checking the type of the first argument (if it's a string, it performs a UDS conneciton).  It then applies any other arguments as an options object passed to `net.Connection()`.

I could have just hijacked the `port` option and passed a string, but this could have un-intended side effects since the host argument is subsequently passed down to the underlying `net.Connection()`.  I figured the best way to avoid this situation would be to add explicit support for unix domain sockets, and not rely on swapping the `port` option to a string type.

Basically, this pull request checks for a `socket` parameter.  If one is present, it will be used, otherwise it will default to the current behavior of using `host` and `port` parameters.  Tests pass with 100% coverage.

Cheers!