### PR TITLE
Upgrade outdated node-redis dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=0.10.30"
   },
   "dependencies": {
-    "redis": "0.12.x",
+    "redis": "2.2.x",
     "hoek": "2.x.x"
   },
   "devDependencies": {
@@ -31,3 +31,4 @@
   },
   "license": "BSD-3-Clause"
 }
+

--- a/test/index.js
+++ b/test/index.js
@@ -503,7 +503,6 @@ describe('Redis', function () {
 
                 expect(redis.isReady()).to.equal(false);
 
-                redis.stop();
                 done();
             });
         });


### PR DESCRIPTION
The node-redis library is a few versions out of date here. Some of the fixes that have gone in to that library include better error handling - in particular, it no longer throws exceptions. Obviously, throwing exceptions here can cause havok to an application, so these changes are particularly desirable.

There are some breaking changes in the updates, but everything seems ok apart from one amend needed in a unit test - it seems to have been a redundant `quit` call, but some clarification on whether this is ok would be good.