### PR TITLE
Allow passing a ready Redis client

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ exports = module.exports = internals.Connection = function (options) {
     Hoek.assert(this.constructor === internals.Connection, 'Redis cache client must be instantiated using new');
 
     this.settings = Hoek.applyToDefaults(internals.defaults, options);
-    this.client = null;
+    this.client = options.client || null;
     return this;
 };
 


### PR DESCRIPTION
An example use-case being passing a Redis client that's able to fail
over, but transparently implements the usual `redis` module API.

This approach has one problem: `Connection#stop` still closes the passed
connection, while in the case of a passed connection this should be up
to the callee, but since `stop` isn't widely used except when closing
down the process, I don't believe this will cause any problems.