### PR TITLE
Drop node 0.10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "redis"
   ],
   "engines": {
-    "node": ">=0.10.30"
+    "node": ">=4.0.0"
   },
   "dependencies": {
     "redis": "2.x.x",


### PR DESCRIPTION
Support for node 0.10 was dropped in 4381ec0f8a7daa15ef669309840ea2b7999eb41e, but the `engines` property was not updated to reflect this change.