### PR TITLE
Deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Lead Maintainer: [Loic Mahieu](https://github.com/LoicMahieu)
 
 The test suite expects:
 - a redis server to be running on port 6379
-- a redis server listenning to port 6378 and requiring a password: 'secret'
-- a redis server listenning on socket `/tmp/redis.sock`
+- a redis server listening to port 6378 and requiring a password: 'secret'
+- a redis server listening on socket `/tmp/redis.sock`
 
 See [.travis.yml](./.travis.yml)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ internals.Connection.prototype.start = function (callback) {
     client.on('error', (err) => {
 
         if (!self.client) {                             // Failed to connect
-            client.end();
+            client.end(false);
             return callback(err);
         }
     });


### PR DESCRIPTION
When failing to connect, the version of node-redis this package depends on throws a deprecation warning because `.end()` is called without a flush parameter.  This PR adds a flush parameter and fixes an unrelated typo I found in the README. Fixes #43 