### PR TITLE
Add option to ignore startup failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Lead Maintainer: [Loic Mahieu](https://github.com/LoicMahieu)
 - `password` - the Redis authentication password when required.
 - `database` - the Redis database.
 - `partition` - this will store items under keys that start with this value. (Default: '')
+- `silentStartFailure` - ignore startup failures. The cache will be unusable, but it won't prevent the server from starting. (Default: false)
 
 ## Tests
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ const internals = {};
 
 internals.defaults = {
     host: '127.0.0.1',
-    port: 6379
+    port: 6379,
+    silentStartupFailure: false
 };
 
 
@@ -60,7 +61,7 @@ internals.Connection.prototype.start = function (callback) {
 
         if (!self.client) {                             // Failed to connect
             client.end(false);
-            return callback(err);
+            return callback(this.settings.silentStartupFailure ? null : err);
         }
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -425,6 +425,24 @@ describe('Redis', () => {
             });
         });
 
+        it('does not return error when connection fails in silent startup failure mode', (done) => {
+
+            const options = {
+                host: '127.0.0.1',
+                port: 6380,
+                silentStartupFailure: true
+            };
+
+            const redis = new Redis(options);
+
+            redis.start((err) => {
+
+                expect(err).to.not.exist();
+                expect(redis.client).to.not.exist();
+                done();
+            });
+        });
+
         it('sends auth command when password is provided', (done) => {
 
             const options = {


### PR DESCRIPTION
This will allow the server to start even when Redis is unavailable. As caching is sometimes just a nice performance enhancement, it can be too drastic to prevent the Hapi-server from start when the cache is unavailable.

GET/SET operations already fail silently for intermittent connection errors.

This should maybe be amended to allow reconnection attempts on startup as well.
