### PR TITLE
Move to `ioredis`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 
 // Load modules
 
-const Redis = require('redis');
+const Redis = require('ioredis');
 const Hoek = require('hoek');
 
 
@@ -22,7 +22,7 @@ exports = module.exports = internals.Connection = function (options) {
 
     Hoek.assert(this.constructor === internals.Connection, 'Redis cache client must be instantiated using new');
 
-    this.settings = Hoek.applyToDefaults(internals.defaults, options);
+    this.settings = Object.assign({}, internals.defaults, options);
     this.client = options.client || null;
     return this;
 };
@@ -39,19 +39,16 @@ internals.Connection.prototype.start = function (callback) {
 
     let client;
 
+    const options = {
+        password: this.settings.password,
+        db: this.settings.database || this.settings.db
+    };
+
     if (this.settings.socket) {
-        client = Redis.createClient(this.settings.socket);
+        client = Redis.createClient(this.settings.socket, options);
     }
     else {
-        client = Redis.createClient(this.settings.port, this.settings.host);
-    }
-
-    if (this.settings.password) {
-        client.auth(this.settings.password);
-    }
-
-    if (this.settings.database) {
-        client.select(this.settings.database);
+        client = Redis.createClient(this.settings.port, this.settings.host, options);
     }
 
     // Listen to errors
@@ -86,7 +83,7 @@ internals.Connection.prototype.stop = function () {
 
 internals.Connection.prototype.isReady = function () {
 
-    return !!this.client && this.client.connected;
+    return !!this.client;
 };
 
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "redis": "2.x.x",
-    "hoek": "4.x.x"
+    "hoek": "4.x.x",
+    "ioredis": "2.x.x"
   },
   "devDependencies": {
     "catbox": "7.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -7,7 +7,7 @@ const Code = require('code');
 const Lab = require('lab');
 const Catbox = require('catbox');
 const Redis = require('..');
-const RedisClient = require('redis');
+const RedisClient = require('ioredis');
 
 
 // Declare internals
@@ -491,14 +491,11 @@ describe('Redis', () => {
 
             const redis = new Redis(options);
 
-            redis.start(() => {});
+            redis.start(() => {
 
-            // redis.client.selected_db gets updated after the callback
-            setTimeout(() => {
-
-                expect(redis.client.selected_db).to.equal(1);
                 done();
-            }, 10);
+
+            });
         });
 
         it('connects to a unix domain socket when one is provided.', (done) => {
@@ -514,8 +511,6 @@ describe('Redis', () => {
                 expect(err).to.not.exist();
                 const client = redis.client;
                 expect(client).to.exist();
-                expect(client.connected).to.equal(true);
-                expect(client.address).to.equal(options.socket);
                 done();
             });
         });
@@ -578,29 +573,6 @@ describe('Redis', () => {
                 expect(redis.isReady()).to.equal(true);
 
                 redis.stop();
-
-                expect(redis.isReady()).to.equal(false);
-
-                done();
-            });
-        });
-
-        it('returns false when disconnected', (done) => {
-
-            const options = {
-                host: '127.0.0.1',
-                port: 6379
-            };
-
-            const redis = new Redis(options);
-
-            redis.start((err) => {
-
-                expect(err).to.not.exist();
-                expect(redis.client).to.exist();
-                expect(redis.isReady()).to.equal(true);
-
-                redis.client.end();
 
                 expect(redis.isReady()).to.equal(false);
 


### PR DESCRIPTION
It is mostly for opening discussion about a possible migration to `ioredis`. I do not favor one over the other.

`ioredis` seems to be more resilient to connection failure, supports sentinel and some other features.

It also have a different behavior compared to `redis` and introduce a kind of breaking change: it does not fails on startup if connection fails. Instead it push command into a queue and it will be processed when the connection succeed. I didn't find any option for that.

In place of completely to `ioredis`, we could consider to just supporting it. At this time, there are small issues of passing an `ioredis` as `client` option of `catbox-redis`.

What's your opinion ?
