### PR TITLE
Accept Redis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Lead Maintainer: [Loic Mahieu](https://github.com/LoicMahieu)
 
 ## Options
 
+- `url` - the Redis server URL (if `url` is provided, `host`, `port`, and `socket` are ignored)
 - `host` - the Redis server hostname. Defaults to `'127.0.0.1'`.
 - `port` - the Redis server port or unix domain socket path. Defaults to `6379`.
 - `socket` - the unix socket string to connect to (if `socket` is provided, `host` and `port` are ignored)

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ internals.Connection.prototype.start = function (callback) {
         password: this.settings.password,
         db: this.settings.database || this.settings.db
     };
-  
+
     if (this.settings.url) {
         client = Redis.createClient(this.settings.url, options);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,10 @@ internals.Connection.prototype.start = function (callback) {
 
     let client;
 
-    if (this.settings.socket) {
+    if (this.settings.url) {
+        client = Redis.createClient(this.settings.url);
+    }
+    else if (this.settings.socket) {
         client = Redis.createClient(this.settings.socket);
     }
     else {

--- a/test/index.js
+++ b/test/index.js
@@ -528,7 +528,6 @@ describe('Redis', () => {
                 expect(err).to.not.exist();
                 const client = redis.client;
                 expect(client).to.exist();
-                expect(client.connected).to.equal(true);
                 done();
             });
         });

--- a/test/index.js
+++ b/test/index.js
@@ -520,6 +520,24 @@ describe('Redis', () => {
             });
         });
 
+        it('connects via a Redis URL when one is provided.', (done) => {
+
+            const options = {
+                url: 'redis://127.0.0.1:6379'
+            };
+
+            const redis = new Redis(options);
+
+            redis.start((err) => {
+
+                expect(err).to.not.exist();
+                const client = redis.client;
+                expect(client).to.exist();
+                expect(client.connected).to.equal(true);
+                done();
+            });
+        });
+
         it('does not stops the client on error post connection', (done) => {
 
             const options = {


### PR DESCRIPTION
Allows a [Redis URL](http://www.iana.org/assignments/uri-schemes/prov/redis) to be passed in via the `url` option. This is especially useful if you just want to pass the `REDIS_URL` environment variable (which is set on Heroku) to catbox-redis.