### PR TITLE
Ensure the client really is ready

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ internals.Connection.prototype.stop = function () {
 
 internals.Connection.prototype.isReady = function () {
 
-    return !!this.client;
+    return !!this.client && this.client.status === 'ready';
 };
 
 


### PR DESCRIPTION
At the moment it's possible for Catbox to return `true` for calls to `.isReady()` when catbox-redis is in a status other than `ready` (such as when ioredis's status is `reconnecting`). When this happens, any function relying on being able to tell if the cache is ready to be called obviously will fail.