### PR TITLE
Changed client instance option in favor of a factory function

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Lead Maintainer: [Loic Mahieu](https://github.com/LoicMahieu)
 - `partition` - this will store items under keys that start with this value. (Default: '')
 - `sentinels` - an array of redis sentinel addresses to connect to.
 - `sentinelName` - the name of the sentinel master. (Only needed when `sentinels` is specified)
+- `client` - a factory function to return a custom `ioredis` client.
 
 ## Tests
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,17 +23,20 @@ exports = module.exports = internals.Connection = function (options) {
     Hoek.assert(this.constructor === internals.Connection, 'Redis cache client must be instantiated using new');
 
     this.settings = Object.assign({}, internals.defaults, options);
-    this.client = null;
+
+    if (options.client) {
+        Hoek.assert(typeof options.client === 'function', 'The client option must be a factory function');
+        this.client = options.client();
+    } else {
+        this.client = null;
+    }
+
     return this;
 };
 
 
 // Async
 internals.Connection.prototype.start = function () {
-
-    if (this.settings.client) {
-        this.client = this.settings.client;
-    }
 
     if (this.client) {
         return Promise.resolve();

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,8 @@ exports = module.exports = internals.Connection = function (options) {
     if (options.client) {
         Hoek.assert(typeof options.client === 'function', 'The client option must be a factory function');
         this.client = options.client();
-    } else {
+    }
+    else {
         this.client = null;
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,17 +24,10 @@ exports = module.exports = internals.Connection = function (options) {
 
     this.settings = Object.assign({}, internals.defaults, options);
 
-    if (options.client) {
-        Hoek.assert(typeof options.client === 'function', 'The client option must be a factory function');
-        this.client = options.client();
-    }
-    else {
-        this.client = null;
-    }
+    this.client = null;
 
     return this;
 };
-
 
 // Async
 internals.Connection.prototype.start = function () {
@@ -63,6 +56,9 @@ internals.Connection.prototype.start = function () {
         }
         else if (this.settings.socket) {
             client = Redis.createClient(this.settings.socket, options);
+        }
+        else if (this.settings.client) {
+            client = this.settings.client();
         }
         else {
             client = Redis.createClient(this.settings.port, this.settings.host, options);

--- a/test/index.js
+++ b/test/index.js
@@ -65,7 +65,7 @@ describe('Redis', () => {
         expect(client.isReady()).to.equal(false);
     });
 
-    it('allow passing client in option', () => {
+    it('allow passing a factory client function in option', () => {
 
         return new Promise((resolve, reject) =>  {
 
@@ -86,7 +86,7 @@ describe('Redis', () => {
             redisClient.once('ready', async () => {
 
                 const client = new Catbox.Client(Redis, {
-                    client: redisClient
+                    client: () => redisClient
                 });
                 await client.start();
                 expect(client.isReady()).to.equal(true);
@@ -110,7 +110,7 @@ describe('Redis', () => {
         });
 
         const client = new Catbox.Client(Redis, {
-            client: redisClient
+            client: () => redisClient
         });
         await client.start();
         expect(client.isReady()).to.equal(true);

--- a/test/index.js
+++ b/test/index.js
@@ -65,49 +65,31 @@ describe('Redis', () => {
         expect(client.isReady()).to.equal(false);
     });
 
-    it('allow passing a factory client function in option', () => {
+    it('allow passing a factory client function in option', async () => {
 
-        return new Promise((resolve, reject) =>  {
+        const redisClient = RedisClient.createClient();
 
-            const redisClient = RedisClient.createClient();
+        let getCalled = false;
+        const _get = redisClient.get;
+        redisClient.get = function (key, callback) {
 
-            let getCalled = false;
-            const _get = redisClient.get;
-            redisClient.get = function (key, callback) {
+            getCalled = true;
+            return _get.apply(redisClient, arguments);
+        };
 
-                getCalled = true;
-                return _get.apply(redisClient, arguments);
-            };
-
-            redisClient.on('error', (err) => {
-
-                reject(err);
-            });
-            redisClient.once('ready', async () => {
-
-                const client = new Catbox.Client(Redis, {
-                    client: () => redisClient
-                });
-                await client.start();
-                expect(client.isReady()).to.equal(true);
-                const key = { id: 'x', segment: 'test' };
-                await client.get(key);
-                expect(getCalled).to.equal(true);
-
-                resolve();
-            });
+        const client = new Catbox.Client(Redis, {
+            client: () => redisClient
         });
+        await client.start();
+        expect(client.isReady()).to.equal(true);
+        const key = { id: 'x', segment: 'test' };
+        await client.get(key);
+        expect(getCalled).to.equal(true);
     });
 
     it('does not stop provided client in options', async () => {
 
         const redisClient = RedisClient.createClient();
-
-        await new Promise((resolve, reject) => {
-
-            redisClient.once('error', reject);
-            redisClient.once('ready', resolve);
-        });
 
         const client = new Catbox.Client(Redis, {
             client: () => redisClient


### PR DESCRIPTION
Hi @LoicMahieu! how are you?

Yesterday I was trying to use a different redis client instance and I notice that catbox never connects to redis using a custom redis client.

Digging in the code I realized that catbox use `applyToDefaults` to the settings and that's ok but it's causing a clone of the redis client instance and that's is the issue.

If we pass a factory function returning the redis custom client everything works great.

This is a PR to change this option if you think it's ok.