### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const cache = new Catbox.Client(CatboxRedis, {
     partition : 'my_cached_data'
     host: 'redis-cluster.domain.com',
     port: 6379,
-    database: 0,
+    db: 0,
     tls: {},
 });
 ```
@@ -74,7 +74,7 @@ const server = new Hapi.Server({
                     partition : 'my_cached_data'
                     host: 'redis-cluster.domain.com',
                     port: 6379,
-                    database: 0,
+                    db: 0,
                     tls: {},
                 }
             }


### PR DESCRIPTION
in line 37 you're reference for the `db` but in the example you're using `database` should be the same.