### PR TITLE
Use PSETEX instead of SET and PEXP

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -191,7 +191,7 @@ module.exports = class {
         return envelope;
     }
 
-    async set(key, value, ttl) {
+    set(key, value, ttl) {
 
         if (!this.client) {
             throw Error('Connection not started');

--- a/lib/index.js
+++ b/lib/index.js
@@ -206,8 +206,7 @@ module.exports = class {
         const cacheKey = this.generateKey(key);
         const stringifiedEnvelope = JSON.stringify(envelope);
 
-        await this.client.set(cacheKey, stringifiedEnvelope);
-        return this.client.pexpire(cacheKey, ttl);
+        return this.client.psetex(cacheKey, ttl, stringifiedEnvelope);
     }
 
     drop(key) {


### PR DESCRIPTION
PSETEX has been supported since Redis 2.6.0, so I think it would make sense to combine the SET and PEXPIRE commands and save on a round trip.