### PR TITLE
Mention redis options pass through

### DIFF
--- a/API.md
+++ b/API.md
@@ -31,6 +31,8 @@ Other supported Redis options:
 - `sentinelName` - the name of the sentinel master (when `sentinels` is specified).
 - `tls` - an object representing TLS config options for **ioredis**.
 
+The plugin also accepts other `redis` options not mentioned above.
+
 
 ## Usage
 


### PR DESCRIPTION
In the follow up of the issue #119, I thought it would be cool to document the plugin options pass through behavior.