### PR TITLE
Support for node v18, ESM tests, upgrade ioredis

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -12,20 +13,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos]
-        node: ['*', '14', '12']
-        hapi: ['20', '19']
-
+        node: ["*", "16", "14"]
     runs-on: ${{ matrix.os }}-latest
-    name: ${{ matrix.os }} node@${{ matrix.node }} hapi@${{ matrix.hapi }}
+    name: ${{ matrix.os }} node@${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
+          check-latest: ${{ matrix.node == '*' }}
       - name: Install
         run: npm install
-      - name: Install hapi
-        run: npm install @hapi/hapi@${{ matrix.hapi }}
       - name: Install docker
         if: matrix.os == 'macos'
         uses: docker-practice/actions-setup-docker@v1

--- a/API.md
+++ b/API.md
@@ -1,5 +1,5 @@
 
-## Options
+### `new CatboxRedis.Engine(options)`
 
 The connection can be specified with one (and only one) of:
 
@@ -34,7 +34,7 @@ Other supported Redis options:
 The plugin also accepts other `redis` options not mentioned above.
 
 
-## Usage
+### Usage
 
 Sample catbox cache initialization:
 
@@ -78,7 +78,7 @@ const server = new Hapi.Server({
 ```
 
 
-## Tests
+### Tests
 
 The test suite expects:
 - a redis server to be running on port 6379

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
-Copyright (c) 2012-2014, Walmart.  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
+Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Bourne = require('@hapi/bourne');
 const Hoek = require('@hapi/hoek');
 const IoRedis = require('ioredis');
 const Joi = require('joi');
@@ -59,7 +60,7 @@ internals.schema.options = Joi.alternatives([
 ]);
 
 
-module.exports = class {
+exports.Engine = class CatboxRedis {
 
     constructor(options = {}) {
 
@@ -148,7 +149,7 @@ module.exports = class {
 
     isReady() {
 
-        return !!this.client && this.client.status === 'ready';
+        return this.client?.status === 'ready';
     }
 
     validateSegmentName(name) {
@@ -176,7 +177,7 @@ module.exports = class {
         }
 
         try {
-            var envelope = JSON.parse(result);
+            var envelope = Bourne.parse(result);
         }
         catch (ignoreErr) { } // Handled by validation below
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "6.0.2",
   "repository": "git://github.com/hapijs/catbox-redis",
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=14.0.0"
   },
   "main": "lib/index.js",
   "files": [
@@ -21,17 +21,17 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x",
-    "ioredis": "4.x.x",
-    "joi": "17.x.x"
+    "@hapi/bourne": "^3.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "ioredis": "^5.0.0",
+    "joi": "^17.0.0"
   },
   "devDependencies": {
-    "@hapi/catbox": "11.x.x",
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/lab": "24.x.x",
-    "redis-parser": "3.x.x"
+    "@hapi/catbox": "^12.0.0",
+    "@hapi/code": "^9.0.1",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/lab": "^25.0.1",
+    "redis-parser": "^3.0.0"
   },
   "scripts": {
     "test": "lab -t 100 -a @hapi/code -L -m 15000",

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const Catbox = require('@hapi/catbox');
-const CatboxRedis = require('..');
-const Code = require('@hapi/code');
 const Hoek = require('@hapi/hoek');
+const Catbox = require('@hapi/catbox');
+const { Engine: CatboxRedis } = require('..');
+
+const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 
 

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let CatboxRedis;
+
+    before(async () => {
+
+        CatboxRedis = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(CatboxRedis)).to.equal([
+            'Engine',
+            'default'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -2,87 +2,19 @@
 
 const Net = require('net');
 
-const Code = require('@hapi/code');
-const Catbox = require('@hapi/catbox');
-const CatboxRedis = require('..');
-const Hapi = require('@hapi/hapi');
-const Hoek = require('@hapi/hoek');
 const IoRedis = require('ioredis');
-const Lab = require('@hapi/lab');
-
+const Catbox = require('@hapi/catbox');
+const Hoek = require('@hapi/hoek');
 const Mock = require('./mock');
+const { Engine: CatboxRedis } = require('..');
 
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
 
 const internals = {};
 
-
 const { it, describe } = exports.lab = Lab.script();
 const expect = Code.expect;
-
-
-describe('hapi', () => {
-
-    const config = (options) => {
-
-        if (require('@hapi/hapi/package.json').version[1] === '7') {
-            options.engine = CatboxRedis;
-            return options;
-        }
-
-        return {
-            provider: {
-                constructor: CatboxRedis,
-                options
-            }
-        };
-    };
-
-    it('uses redis server for caching', async () => {
-
-        const server = Hapi.server({
-            cache: config({
-                host: '127.0.0.1',
-                port: 6379,
-                partition: 'hapi-test-redis'
-            })
-        });
-
-        const cache = server.cache({ segment: 'test', expiresIn: 1000 });
-        await server.initialize();
-
-        await cache.set('a', 'going in');
-        expect(await cache.get('a')).to.equal('going in');
-    });
-
-    it('uses redis cluster for caching', async () => {
-
-        const server = Hapi.server({
-            cache: config({
-                cluster: [
-                    {
-                        host: '127.0.0.1',
-                        port: 7000
-                    },
-                    {
-                        host: '127.0.0.1',
-                        port: 7001
-                    },
-                    {
-                        host: '127.0.0.1',
-                        port: 7002
-                    }
-                ],
-                partition: 'hapi-test-redis'
-            })
-        });
-
-        const cache = server.cache({ segment: 'test', expiresIn: 1000 });
-        await server.initialize();
-
-        await cache.set('a', 'going in');
-        expect(await cache.get('a')).to.equal('going in');
-    });
-});
 
 describe('Connection', { retry: true }, () => {
 
@@ -460,7 +392,7 @@ describe('Connection', { retry: true }, () => {
 
         it('connects to a unix domain socket when one is provided', () => {
 
-            const socketPath = '/tmp/redis.sock';
+            const socketPath = '/tmp/catbox-redis.sock';
             const promise = new Promise((resolve, reject) => {
 
                 let connected = false;

--- a/test/mock.js
+++ b/test/mock.js
@@ -39,7 +39,7 @@ module.exports = internals.MockServer = class extends EventEmitter {
                 returnReply: (reply) => {
 
                     reply = this.convertBufferToString(reply);
-                    this.write(socket, this.handler && this.handler(reply));
+                    this.write(socket, this.handler?.(reply));
                 },
                 returnError: function () {}
             });


### PR DESCRIPTION
 - Support and test on node v18.
 - Update all deps for node v18.
 - Test ESM support.
 - Update export to `Engine` to be more ESM-friendly.
 - Parse envelopes with bourne.
 - Upgrade ioredis to v5.

If this looks good, this will go out as catbox-redis v7.
